### PR TITLE
Specr copy

### DIFF
--- a/autoload/specr.vim
+++ b/autoload/specr.vim
@@ -4,19 +4,21 @@
 " RUN
 function! specr#run(...) abort
   if empty(a:000)
-    let s:found_filepath = call DirectSpec(expand('%'))
+    call RenderSpec(DirectSpec(expand('%')))
   else
-    let s:found_filepath = call DirectSpec(a:1)
+    call RenderSpec(DirectSpec(a:1))
   end
-  call RenderSpec(s:found_filepath)
 endfunction
 
 
 " COPY
 function! specr#copy(...) abort
-  let l:found_filepath = call DirectSpec(expand('%'))
-  +=l:found_filepath
+  let l:found_filepath = DirectSpec(expand('%'))
+  let l:message = join(["RSpec path: '", l:found_filepath, "' copied to system clipboard."], '')
+  echom l:message
+  let @+ = l:found_filepath
 endfunction
+
 
 
 function! DirectSpec(argpath) abort

--- a/autoload/specr.vim
+++ b/autoload/specr.vim
@@ -1,12 +1,21 @@
 " SPECR PLUGIN
 
 
+" RUN
 function! specr#run(...) abort
   if empty(a:000)
-    call DirectSpec(expand('%'))
+    let s:found_filepath = call DirectSpec(expand('%'))
   else
-    call DirectSpec(a:1)
+    let s:found_filepath = call DirectSpec(a:1)
   end
+  call RenderSpec(s:found_filepath)
+endfunction
+
+
+" COPY
+function! specr#copy(...) abort
+  let l:found_filepath = call DirectSpec(expand('%'))
+  +=l:found_filepath
 endfunction
 
 
@@ -14,9 +23,9 @@ function! DirectSpec(argpath) abort
   " Example of true statement: spec/folder1/folder2/controller_spec.rb (exists)
 
   if and(split(a:argpath, '/')[0] == 'spec', a:argpath[-7:-1] == 'spec.rb')
-    call RenderSpec( a:argpath )
+    return a:argpath
   else
-    call FindSpecLiteral(a:argpath)
+    return FindSpecLiteral(a:argpath)
   endif
 endfunction
 
@@ -28,9 +37,9 @@ function! FindSpecLiteral(argpath) abort
   let l:lookup_filepath = join(['spec'] + split(a:argpath, '/')[1:-2] + [l:lookup_filename], '/')
 
   if filereadable(l:lookup_filepath)
-    call RenderSpec( l:lookup_filepath )
+    return l:lookup_filepath
   else
-    call FindSpecGlob(a:argpath)
+    return FindSpecGlob(a:argpath)
   endif
 endfunction
 
@@ -44,9 +53,9 @@ function! FindSpecGlob(argpath) abort
   let l:lookup_result = glob(l:lookup_string)
 
   if filereadable(l:lookup_result)
-    call RenderSpec( l:lookup_result )
+    return l:lookup_result
   else
-    call RenderSpec( FindSpecDir(a:argpath) )
+    return FindSpecDir(a:argpath)
   endif
 endfunction
 

--- a/plugin/specr.vim
+++ b/plugin/specr.vim
@@ -1,2 +1,5 @@
-nnoremap <Plug>Specr :call specr#run()<CR>
-nmap <leader>t <Plug>Specr
+nnoremap <Plug>SpecrRun :call specr#run()<CR>
+nmap <leader>t <Plug>SpecrRun
+
+nnoremap <Plug>SpecrCopy :call specr#copy()<CR>
+nmap <leader>ty <Plug>SpecrCopy


### PR DESCRIPTION

**branch goal:**
Add a new function that copies the path of the found rspec file to the system clipboard.
This can be useful for quickly launching an rspec outside of vim or pasting the path elsewhere.

Pulled out the RenderSpec() method into specr#run(). This should allow us to
work with the finalized, found spec_path for other things. like sending
it to a register.

- Added an output message showing what was copied.